### PR TITLE
Fix "realpath command not found" error on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ If you're looking to use our RL code, you'll need additionally:
 On Mac, a Nvidia GPU is not required, but the environment rendering is not headless - you'll see a godot window pop up for each environment you have open.
 
 ```
+brew install coreutils
 pip install avalon-rl
 python -m avalon.install_godot_binary runner
 python -m avalon.common.check_install


### PR DESCRIPTION
### Issue
When running on Mac, quickstart resulted in `realpath command not found` crash at `avalon/datagen/godot/datagen.sh` (Line 16).

### Solution
This was [solved](https://unix.stackexchange.com/questions/101080/realpath-command-not-found) with `brew install coreutils`.