### PR TITLE
Fix NDArray check when wrapping observations

### DIFF
--- a/avalon/agent/common/wrappers.py
+++ b/avalon/agent/common/wrappers.py
@@ -80,7 +80,7 @@ class DictObsActionWrapper(Wrapper[DictObservationType, DictActionType]):
 
     def observation(self, observation: Union[NDArray, DictObservationType]) -> DictObservationType:
         if self.wrapped_obs:
-            assert type(observation) == NDArray
+            assert isinstance(observation, NDArray)
             return {self.obs_key: observation}
         else:
             return observation


### PR DESCRIPTION
This would previously break the DictObsActionWrapper when using it with an environment that does not natively come with dictionary observations.

Since the type of `observation` would typically by `numpy.ndarray`, which is not equal to `nptyping.NDArray`, the assertion would fail. What we actually want to check here is that `observation` has an interface that is compatible with `nptyping.NDArray` though.