### PR TITLE
Make sentry usage configurable

### DIFF
--- a/avalon/agent/common/worker.py
+++ b/avalon/agent/common/worker.py
@@ -484,8 +484,8 @@ class EnvironmentContainerProcess:
 
     def lazy_init_env(self) -> None:
         if self.env is None:
+            # Uses the SENTRY_DSN environment variable. No events are sent if the variable is not set.
             sentry_sdk.init(  # type: ignore[abstract]
-                dsn="https://198a62315b2c4c2a99cb8a5493224e2f@o568344.ingest.sentry.io/6453090",
                 # Set traces_sample_rate to 1.0 to capture 100%
                 # of transactions for performance monitoring.
                 # We recommend adjusting this value in production.

--- a/avalon/agent/random_eval/evaluation.py
+++ b/avalon/agent/random_eval/evaluation.py
@@ -83,8 +83,8 @@ def run_evaluation(worlds_path: Path, data_key: str, seed: int) -> None:
 
     s3_client = SimpleS3Client()
 
+    # Uses the SENTRY_DSN environment variable. No events are sent if the variable is not set.
     sentry_sdk.init(  # type: ignore
-        dsn="https://198a62315b2c4c2a99cb8a5493224e2f@o568344.ingest.sentry.io/6453090",
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.

--- a/avalon/agent/torchbeast/evaluation.py
+++ b/avalon/agent/torchbeast/evaluation.py
@@ -75,8 +75,8 @@ def run_evaluation(worlds_path: Path, data_key: Optional[str], wandb_run: str, c
     s3_client = SimpleS3Client()
     result_key = get_wandb_result_key(wandb_run, checkpoint_filename, data_key)
 
+    # Uses the SENTRY_DSN environment variable. No events are sent if the variable is not set.
     sentry_sdk.init(
-        dsn="https://198a62315b2c4c2a99cb8a5493224e2f@o568344.ingest.sentry.io/6453090",
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.

--- a/avalon/agent/torchbeast/polybeast_learner.py
+++ b/avalon/agent/torchbeast/polybeast_learner.py
@@ -683,8 +683,8 @@ def main(flags):
     if not flags.pipes_basename.startswith("unix:"):
         raise Exception("--pipes_basename has to be of the form unix:/some/path.")
 
+    # Uses the SENTRY_DSN environment variable. No events are sent if the variable is not set.
     sentry_sdk.init(
-        dsn="https://198a62315b2c4c2a99cb8a5493224e2f@o568344.ingest.sentry.io/6453090",
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.

--- a/avalon/server/app.py
+++ b/avalon/server/app.py
@@ -37,8 +37,8 @@ APK_DIR = Path(ENV_ROOT_PATH) / "apks" / API_VERSION
 APK_DIR.mkdir(parents=True, exist_ok=True)
 
 if IS_SENTRY_ENABLED:
+    # Uses the SENTRY_DSN environment variable. No events are sent if the variable is not set.
     sentry_sdk.init(
-        dsn="https://198a62315b2c4c2a99cb8a5493224e2f@o568344.ingest.sentry.io/6453090",
         integrations=[FlaskIntegration()],
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.


### PR DESCRIPTION
(I realize that [this comment](https://github.com/Avalon-Benchmark/avalon/pull/10#issuecomment-1315124538) will apply here as well. I'm just in the process of cleaning up my changes to avalon, so I'll leave that here for possible consideration in the future.) 

It should be possible to use avalon and the baseline agents without sending data to the pre-configured sentry project. This change makes it possible to configure a custom sentry project. It is also possible to disable logging to sentry altogether by leaving SENTRY_DSN unset [1].

[1] https://docs.sentry.io/product/sentry-basics/dsn-explainer/#what-the-dsn-does


Note that this means that `SENTRY_DSN` now needs to be set in order to achieve the previous default behavior. This is just a proposal based on what I think would be a better default behavior, of course I realize that you may disagree. In that case feel free to close the PR or suggest an alternative.