### PR TITLE
Update to gym 0.26

### DIFF
--- a/avalon/agent/common/test_envs.py
+++ b/avalon/agent/common/test_envs.py
@@ -79,16 +79,18 @@ class DummyEnv:
     def reset(self):
         self._step = 0
         obs = np.zeros((3, 84, 84), dtype=np.float32)
-        return obs
+        info = dict()
+        return obs, info
 
     def step(self, action):
         obs = np.zeros((3, 84, 84), dtype=np.float32)
         # obs = self.observation_space.sample()
         reward = self._random.uniform(0, 1).astype(np.float32)
         self._step += 1
-        done = self._step >= 1000
+        terminated = self._step >= 1000
+        truncated = False
         info = {}
-        return obs, reward, done, info
+        return obs, reward, terminated, truncated, info
 
     def close(self):
         pass
@@ -124,15 +126,17 @@ class Test1:
     def reset(self):
         self._step = 0
         obs = np.zeros((1,), dtype=np.float32)
-        return obs
+        info = dict()
+        return obs, info
 
     def step(self, action):
         obs = np.zeros((1,), dtype=np.float32)
         reward = float(1)
         self._step += 1
-        done = self._step >= self.num_steps
+        terminated = self._step >= self.num_steps
+        truncated = False
         info = {}
-        return obs, reward, done, info
+        return obs, reward, terminated, truncated, info
 
     def close(self):
         pass
@@ -160,7 +164,8 @@ class Test2:
     def reset(self):
         self._step = 0
         obs = np.zeros((1,), dtype=np.float32)
-        return obs
+        info = dict()
+        return obs, info
 
     def step(self, action):
         assert isinstance(action, int)
@@ -173,13 +178,14 @@ class Test2:
         else:
             assert False
         self._step += 1
-        done = self._step >= self.num_steps
+        terminated = self._step >= self.num_steps
+        truncated = False
         info = {}
         # high is non-inclusive.
         obs = np.random.randint(0, 2, size=(1,)).astype(np.float32) * 2 - 1
         # obs = np.random.uniform(-1, 1, size=(1,))
         self.last_obs = obs
-        return obs.astype(dtype=np.float32), reward, done, info
+        return obs.astype(dtype=np.float32), reward, terminated, truncated, info
 
     def close(self):
         pass
@@ -204,7 +210,8 @@ class TestHybridAction:
     def reset(self):
         self._step = 0
         obs = np.zeros((1,)).astype(np.float32)
-        return obs
+        info = dict()
+        return obs, info
 
     def step(self, action):
         # TODO: continuous actions come in as an array, discrete come in as integers.
@@ -220,11 +227,12 @@ class TestHybridAction:
         reward = -1 * (self.last_obs.item() - (continuous * (discrete * 2 - 1))) ** 2
 
         self._step += 1
-        done = self._step >= self.num_steps
+        terminated = self._step >= self.num_steps
+        truncated = False
         info = {}
         obs = np.random.uniform(-1, 1, size=(1,)).astype(np.float32)
         self.last_obs = obs
-        return obs, reward, done, info
+        return obs, reward, terminated, truncated, info
 
     def close(self):
         pass

--- a/avalon/agent/random/evaluation.py
+++ b/avalon/agent/random/evaluation.py
@@ -39,7 +39,7 @@ class RandomActionDistribution:
 @torch.no_grad()
 def do_eval_rollouts(policy: RandomActionDistribution, env: GodotEnv) -> Dict[str, float]:
     # DO ROLLOUTS
-    observation = env.reset()
+    observation, _ = env.reset()
     frame_count = 1
     scores_by_world_index: Dict[str, float] = {}
     while True:

--- a/avalon/agent/torchbeast/atari_wrappers.py
+++ b/avalon/agent/torchbeast/atari_wrappers.py
@@ -58,10 +58,10 @@ class NoopResetEnv(gym.Wrapper):
         assert noops > 0
         obs = None
         for _ in range(noops):
-            obs, _, done, _ = self.env.step(self.noop_action)
-            if done:
-                obs = self.env.reset(**kwargs)
-        return obs
+            obs, _, terminated, truncated, info = self.env.step(self.noop_action)
+            if terminated or truncated:
+                obs, info = self.env.reset(**kwargs)
+        return obs, info
 
     def step(self, ac):
         return self.env.step(ac)
@@ -76,13 +76,13 @@ class FireResetEnv(gym.Wrapper):
 
     def reset(self, **kwargs):
         self.env.reset(**kwargs)
-        obs, _, done, _ = self.env.step(1)
-        if done:
+        obs, _, terminated, truncated, info = self.env.step(1)
+        if terminated or truncated:
             self.env.reset(**kwargs)
-        obs, _, done, _ = self.env.step(2)
-        if done:
+        obs, terminated, truncated, done, info = self.env.step(2)
+        if terminated or truncated:
             self.env.reset(**kwargs)
-        return obs
+        return obs, info
 
     def step(self, ac):
         return self.env.step(ac)
@@ -98,8 +98,8 @@ class EpisodicLifeEnv(gym.Wrapper):
         self.was_real_done = True
 
     def step(self, action):
-        obs, reward, done, info = self.env.step(action)
-        self.was_real_done = done
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        self.was_real_done = terminated
         # check current lives, make loss of life terminal,
         # then update lives to handle bonus lives
         lives = self.env.unwrapped.ale.lives()
@@ -107,9 +107,9 @@ class EpisodicLifeEnv(gym.Wrapper):
             # for Qbert sometimes we stay in lives == 0 condition for a few frames
             # so it's important to keep lives > 0, so that we only reset once
             # the environment advertises done.
-            done = True
+            terminated = True
         self.lives = lives
-        return obs, reward, done, info
+        return obs, reward, terminated, truncated, info
 
     def reset(self, **kwargs):
         """Reset only when lives are exhausted.
@@ -117,12 +117,12 @@ class EpisodicLifeEnv(gym.Wrapper):
         and the learner need not know about any of this behind-the-scenes.
         """
         if self.was_real_done:
-            obs = self.env.reset(**kwargs)
+            obs, info = self.env.reset(**kwargs)
         else:
             # no-op step to advance from terminal/lost life state
-            obs, _, _, _ = self.env.step(0)
+            obs, _, _, info = self.env.step(0)
         self.lives = self.env.unwrapped.ale.lives()
-        return obs
+        return obs, info
 
 
 class MaxAndSkipEnv(gym.Wrapper):
@@ -136,21 +136,22 @@ class MaxAndSkipEnv(gym.Wrapper):
     def step(self, action):
         """Repeat action, sum reward, and max over last observations."""
         total_reward = 0.0
-        done = None
+        terminated = None
+        truncated = None
         for i in range(self._skip):
-            obs, reward, done, info = self.env.step(action)
+            obs, reward, terminated, truncated, info = self.env.step(action)
             if i == self._skip - 2:
                 self._obs_buffer[0] = obs
             if i == self._skip - 1:
                 self._obs_buffer[1] = obs
             total_reward += reward
-            if done:
+            if terminated or truncated:
                 break
         # Note that the observation on the done=True frame
         # doesn't matter
         max_frame = self._obs_buffer.max(axis=0)
 
-        return max_frame, total_reward, done, info
+        return max_frame, total_reward, terminated, truncated, info
 
     def reset(self, **kwargs):
         return self.env.reset(**kwargs)
@@ -236,15 +237,15 @@ class FrameStack(gym.Wrapper):
         )
 
     def reset(self):
-        ob = self.env.reset()
+        ob, info = self.env.reset()
         for _ in range(self.k):
             self.frames.append(ob)
-        return self._get_ob()
+        return self._get_ob(), info
 
     def step(self, action):
-        ob, reward, done, info = self.env.step(action)
+        ob, reward, terminated, truncated, info = self.env.step(action)
         self.frames.append(ob)
-        return self._get_ob(), reward, done, info
+        return self._get_ob(), reward, terminated, truncated, info
 
     def _get_ob(self):
         assert len(self.frames) == self.k

--- a/avalon/agent/torchbeast/avalon_helpers.py
+++ b/avalon/agent/torchbeast/avalon_helpers.py
@@ -54,9 +54,9 @@ class DictifyAtari(gym.Wrapper):
     def step(self, action: np.ndarray):
         """Repeat action, sum reward, and max over last observations."""
         action_dict = spaces.utils.unflatten(self.action_space, action)
-        obs, reward, done, info = self.env.step(action_dict["discrete"])
+        obs, reward, terminated, truncated, info = self.env.step(action_dict["discrete"])
 
-        return obs, reward, done, info
+        return obs, reward, terminated, truncated, info
 
     def reset(self, **kwargs):
         return self.env.reset(**kwargs)
@@ -405,8 +405,8 @@ class CurriculumWrapper(Wrapper):
             self.load_curriculum_state_from_file_if_exists()
 
     def step(self, action: Dict[str, torch.Tensor]):
-        observation, reward, done, info = self.env.step(action)
-        if done:
+        observation, reward, terminated, truncated, info = self.env.step(action)
+        if terminated or truncated:
             task = AvalonTask[info["task"]]
             update_step = self.task_difficulty_update  # * np.random.uniform()
             if info["success"] == 1:
@@ -422,7 +422,7 @@ class CurriculumWrapper(Wrapper):
             self.env.set_task_difficulty(task, self.difficulties[task])
             self.env.set_meta_difficulty(self.meta_difficulty)
             self.save_curriculum_state_to_file()
-        return observation, reward, done, info
+        return observation, reward, terminated, truncated, info
 
     def save_curriculum_state_to_file(self):
         with open(self.env.curriculum_save_path, "wb") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "boto3 >= 1.20.47",
   "einops >= 0.3.2",
   "godot-parser >= 0.1.6",
-  "gym == 0.25.2",
+  "gym >= 0.26.0",
   "IPython >= 8.5.0",
   "loguru >= 0.6.0",
   "matplotlib >= 3.5.1",


### PR DESCRIPTION
Note: I realize that this is a big change and you may decide not to merge this. I worked on it for my own purposes (applying the avalon dreamer baseline to gym 0.26 environments) and thought it would be best to propose it upstream, but I understand if you decide to close the PR. I have also not tested this exhaustively, I have only verified that it works for my purposes. So it is likely that there are still some mistakes and this PR would be a starting point rather than an immediately mergeable.

If you want me to run the test suite, I'd be happy to. In that case please let me know how best to do that (use the dockerfile? pytest?).

---

See [1] for a list of breaking changes. In particular we now

- need to pass "render_mode" when initializing a gym environment, especially
  when we want to PixelObservationWrapper later,

- need to split `done` into `truncated` and `terminated` and

- need to return `info` in `reset`.

Note that future Gym development will happen in the "Gymnasium" [2] fork, which
is based on Gym 0.26. Migrating from Gym 0.26 to Gymnasium should be easy.

[1] https://github.com/openai/gym/releases/tag/0.26.0
[2] https://github.com/Farama-Foundation/Gymnasium
