### PR TITLE
Add support for custom environments

### DIFF
--- a/avalon/agent/common/envs.py
+++ b/avalon/agent/common/envs.py
@@ -101,6 +101,10 @@ def build_env(env_params: EnvironmentParams) -> gym.Env:
         env = wrappers.OneHotActionWrapper(env)
         if env_params.elapsed_time_obs:
             env = wrappers.ElapsedTimeWrapper(env, max_steps)
+    elif env_params.suite == "builder":
+        env = env_params.task()
+        env = wrappers.DictObsActionWrapper(env, obs_key="obs")
+        env = wrappers.OneHotActionWrapper(env)
     elif env_params.suite == "atari":
         assert env_params.task is not None
         assert env_params.action_repeat == 4


### PR DESCRIPTION
I found this useful when applying to baseline agents to environments with custom wrappers. I understand that you may consider this out of scope for avalon, feel free to reject the PR in that case.

---

This makes it possible to use custom Gym environments by specifying the suite "builder" and passing a function to "task" that expects no parameters and returns a gym environment when called.

One example use case is to use gym environments with a pre-applied set of wrappers.